### PR TITLE
Add 3 publications from issue #1 (R. Sefala, 2025)

### DIFF
--- a/_publications/2025-04-01-bridging-the-gap-integrating-ethics-and-environmental-sustai.md
+++ b/_publications/2025-04-01-bridging-the-gap-integrating-ethics-and-environmental-sustai.md
@@ -1,0 +1,13 @@
+---
+title: "Bridging the Gap: Integrating Ethics and Environmental Sustainability in AI Research and Practice"
+collection: publications
+category: preprints
+permalink: /publication/2025-04-01-bridging-the-gap-integrating-ethics-and-environmental-sustai
+excerpt: 'A 2025 arXiv preprint proposing an integrated approach that bridges ethics and environmental sustainability in AI research and practice.'
+date: 2025-04-01
+venue: 'arXiv'
+paperurl: 'https://arxiv.org/abs/2504.00797'
+citation: 'Luccioni, A.S., Pistilli, G., Sefala, R. and Moorosi, N., 2025. &quot;Bridging the Gap: Integrating Ethics and Environmental Sustainability in AI Research and Practice.&quot; <i>arXiv preprint arXiv:2504.00797</i>.'
+---
+
+A 2025 arXiv preprint proposing an integrated approach that bridges ethics and environmental sustainability in AI research and practice.

--- a/_publications/2025-06-23-the-world-wide-recipe-a-community-centred-framework-for-fine.md
+++ b/_publications/2025-06-23-the-world-wide-recipe-a-community-centred-framework-for-fine.md
@@ -1,0 +1,13 @@
+---
+title: "The World Wide Recipe: A Community-Centred Framework for Fine-Grained Data Collection and Regional Bias Operationalisation"
+collection: publications
+category: conferences
+permalink: /publication/2025-06-23-the-world-wide-recipe-a-community-centred-framework-for-fine
+excerpt: 'A community-centred framework presented at FAccT 2025 for fine-grained data collection and operationalising regional bias.'
+date: 2025-06-23
+venue: 'Proceedings of the 2025 ACM Conference on Fairness, Accountability, and Transparency'
+paperurl: 'https://doi.org/10.1145/3715275.3732019'
+citation: 'Magomere, J., Ishida, S., Afonja, T., Salama, A., Kochin, D., Foutse, Y., Hamzaoui, I., Sefala, R., Alaagib, A., Dalal, S. and Marchegiani, B., 2025. &quot;The World Wide recipe: A community-centred framework for fine-grained data collection and regional bias operationalisation.&quot; In <i>Proceedings of the 2025 ACM Conference on Fairness, Accountability, and Transparency</i>, pp. 246-282.'
+---
+
+A community-centred framework presented at FAccT 2025 for fine-grained data collection and operationalising regional bias.

--- a/_publications/2025-10-16-the-human-labour-of-data-work-capturing-cultural-diversity-t.md
+++ b/_publications/2025-10-16-the-human-labour-of-data-work-capturing-cultural-diversity-t.md
@@ -1,0 +1,13 @@
+---
+title: "The Human Labour of Data Work: Capturing Cultural Diversity through World Wide Dishes"
+collection: publications
+category: manuscripts
+permalink: /publication/2025-10-16-the-human-labour-of-data-work-capturing-cultural-diversity-t
+excerpt: 'A 2025 PACM HCI article examining how cultural diversity is captured in data work through the World Wide Dishes project.'
+date: 2025-10-16
+venue: 'Proceedings of the ACM on Human-Computer Interaction'
+paperurl: 'https://doi.org/10.1145/3757673'
+citation: 'Hall, S.M., Dalal, S., Sefala, R., Yuehgoh, F., Alaagib, A., Hamzaoui, I., Ishida, S., Magomere, J., Crais, L., Salama, A. and Afonja, T., 2025. &quot;The human labour of data work: Capturing cultural diversity through world wide dishes.&quot; <i>Proceedings of the ACM on Human-Computer Interaction</i>, 9(7), pp.1-43.'
+---
+
+A 2025 PACM HCI article examining how cultural diversity is captured in data work through the World Wide Dishes project.


### PR DESCRIPTION
Closes #1

Adds three 2025 publications from @sefalab's issue to the `_publications/` collection.

## Publications added

| File | Category | Venue | Date |
|------|----------|-------|------|
| `2025-10-16-the-human-labour-of-data-work-*.md` | manuscripts | Proc. ACM HCI 9(7) | 2025-10-16 |
| `2025-06-23-the-world-wide-recipe-*.md` | conferences | FAccT 2025 | 2025-06-23 |
| `2025-04-01-bridging-the-gap-*.md` | preprints | arXiv:2504.00797 | 2025-04-01 |

## Sources / URLs

- Hall et al. 2025 — [doi.org/10.1145/3757673](https://doi.org/10.1145/3757673) — *The Human Labour of Data Work: Capturing Cultural Diversity through World Wide Dishes*
- Magomere et al. 2025 — [doi.org/10.1145/3715275.3732019](https://doi.org/10.1145/3715275.3732019) — *The World Wide Recipe: A Community-Centred Framework for Fine-Grained Data Collection and Regional Bias Operationalisation*
- Luccioni et al. 2025 — [arxiv.org/abs/2504.00797](https://arxiv.org/abs/2504.00797) — *Bridging the Gap: Integrating Ethics and Environmental Sustainability in AI Research and Practice*

## Notes

- Categories: `manuscripts` for the PACMHCI journal article, `conferences` for FAccT, `preprints` for arXiv.
- DOIs resolved via Crossref; arXiv published date taken from the arXiv API.
- Excerpts are short factual summaries derived from titles — happy to revise with author-provided abstracts.
- Generated automatically from issue #1 via a runbook; please verify citation formatting before merging.

Made with [Cursor](https://cursor.com)