### PR TITLE
Add publication: Towards Open-Ended Discovery for Low-Resource NLP

### DIFF
--- a/_publications/2025-11-01-towards-open-ended-discovery-for-low-resource-nlp.md
+++ b/_publications/2025-11-01-towards-open-ended-discovery-for-low-resource-nlp.md
@@ -1,0 +1,13 @@
+---
+title: "Towards Open-Ended Discovery for Low-Resource NLP"
+collection: publications
+category: workshops
+permalink: /publication/2025-11-01-towards-open-ended-discovery-for-low-resource-nlp
+excerpt: 'This paper proposes a paradigm shift in language technology where AI systems learn new languages dynamically through interactive dialogue rather than static datasets. It introduces a framework combining model uncertainty with human speaker confidence signals to guide learning in under-documented languages.'
+date: 2025-11-01
+venue: '2nd Workshop on Uncertainty-Aware NLP (UncertaiNLP 2025)'
+paperurl: 'https://aclanthology.org/2025.uncertainlp-main.24/'
+citation: 'Dossou, B.F.P. and Aïdasso, H. (2025). &quot;Towards Open-Ended Discovery for Low-Resource NLP.&quot; <i>Proceedings of the 2nd Workshop on Uncertainty-Aware NLP (UncertaiNLP 2025)</i>.'
+---
+
+This paper proposes a paradigm shift in language technology where AI systems learn new languages dynamically through interactive dialogue rather than static datasets. It introduces a framework combining model uncertainty with human speaker confidence signals to guide learning in under-documented languages, emphasizing human-centered, participatory approaches to low-resource NLP.


### PR DESCRIPTION
Closes #2

Adds a new publication from issue #2.

- **Title:** Towards Open-Ended Discovery for Low-Resource NLP
- **Venue:** 2nd Workshop on Uncertainty-Aware NLP (UncertaiNLP 2025)
- **Date:** 2025-11-01
- **Category:** workshops
- **Paper:** https://aclanthology.org/2025.uncertainlp-main.24/

Generated automatically from the linked issue.